### PR TITLE
pyjwt instead of jwt is required for encode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     extras_require={
         "server": [
             "etcd3", "fastapi", "uvicorn[standard]", "pydantic>=2.5.0",
-            'jsonpatch', "jwt",
+            'jsonpatch', "pyjwt",
         ],
         "dev": [
             "yapf==0.32.0", "pylint==2.8.2", "pylint-quotes==0.2.3",


### PR DESCRIPTION
Changed jwt --> pyjwt for encode:  with jwt, launching the api server fails with the following.

```
$ python api_server/launch_server.py --workers=1 --port 2380
[Installer] ETCD is running.
INFO:     Started server process [75884]
INFO:     Waiting for application startup.
ERROR:    Traceback (most recent call last):
  File "/Users/testdriver/miniconda3/envs/skyflow-1/lib/python3.9/site-packages/starlette/routing.py", line 734, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/Users/testdriver/miniconda3/envs/skyflow-1/lib/python3.9/site-packages/starlette/routing.py", line 610, in __aenter__
    await self._router.startup()
  File "/Users/testdriver/miniconda3/envs/skyflow-1/lib/python3.9/site-packages/starlette/routing.py", line 713, in startup
    handler()
  File "/Users/testdriver/Documents/GitHub/skyflow/api_server/api_server.py", line 65, in check_or_wait_initialization
    api_server.installation_hook()
  File "/Users/testdriver/Documents/GitHub/skyflow/api_server/api_server.py", line 108, in installation_hook
    self._login_user(ADMIN_USER, ADMIN_PWD)
  File "/Users/testdriver/Documents/GitHub/skyflow/api_server/api_server.py", line 199, in _login_user
    access_token = create_access_token(
  File "/Users/testdriver/Documents/GitHub/skyflow/api_server/api_utils.py", line 28, in create_access_token
    encoded_jwt: str = jwt.encode(to_encode, secret_key, algorithm='HS512')
AttributeError: module 'jwt' has no attribute 'encode'

ERROR:    Application startup failed. Exiting.
```

With this change in a clean environment: 
```
$ python api_server/launch_server.py --workers=1 
[Installer] ETCD is running.
INFO:     Started server process [77313]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:50051 (Press CTRL+C to quit)

```
 