### PR TITLE
Add requests_unixsocket to requirements 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,12 @@ setup(
         'python-multipart', "pytest", "pyyaml", "requests>=2.31.0", "rich",
         "tabulate", "types-passlib", "types-psutil", "types-tabulate",
         "types-PyYAML", "types-requests", "skypilot[aws,gcp,azure,kubernetes]",
-        "bcrypt==4.0.1", "paramiko", "types-paramiko"
+        "bcrypt==4.0.1", "paramiko", "types-paramiko", "requests_unixsocket"
     ],
     extras_require={
         "server": [
             "etcd3", "fastapi", "uvicorn[standard]", "pydantic>=2.5.0",
-            'jsonpatch', "pyjwt", "requests_unixsocket"
+            'jsonpatch', "pyjwt",
         ],
         "dev": [
             "yapf==0.32.0", "pylint==2.8.2", "pylint-quotes==0.2.3",


### PR DESCRIPTION
Launching the API server in a fresh conda environment with the slurm branch installed (and the slurm branch with main merged in) produces the following stack trace. Adding `requests_unixsocket` to setup.py[server] produces the same results as the "apparent resolution" below.


**Stack trace**
(Similar stack trace can be produced with just `$ skyctl --help`)

```
$ python api_server/launch_server.py --workers=1
[Installer] ETCD is running.
API server config already exists. Skipping generation.
Traceback (most recent call last):
  File "/Users/tester/Documents/GitHub/skyflow/api_server/launch_server.py", line 103, in <module>
    main(args.host, args.port, args.workers, args.data_directory)
  File "/Users/tester/Documents/GitHub/skyflow/api_server/launch_server.py", line 60, in main
    uvicorn.run(
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/main.py", line 575, in run
    server.run()
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/server.py", line 62, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/server.py", line 69, in serve
    config.load()
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/config.py", line 433, in load
    self.loaded_app = import_from_string(self.app)
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/importer.py", line 22, in import_from_string
    raise exc from None
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
  File "/Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/tester/Documents/GitHub/skyflow/api_server/api_server.py", line 22, in <module>
    from skyflow.cluster_manager.kubernetes_manager import K8ConnectionError
  File "/Users/tester/Documents/GitHub/skyflow/skyflow/cluster_manager/__init__.py", line 6, in <module>
    from skyflow.cluster_manager.manager_utils import setup_cluster_manager
  File "/Users/tester/Documents/GitHub/skyflow/skyflow/cluster_manager/manager_utils.py", line 12, in <module>
    from skyflow.cluster_manager.slurm_manager_rest import SlurmManagerREST
  File "/Users/tester/Documents/GitHub/skyflow/skyflow/cluster_manager/slurm_manager_rest.py", line 12, in <module>
    import requests_unixsocket
ModuleNotFoundError: No module named 'requests_unixsocket'
```

Apparent resolution
```
$ pip install requests_unixsocket
Collecting requests_unixsocket
  Downloading requests_unixsocket-0.3.0-py2.py3-none-any.whl.metadata (3.6 kB)
Requirement already satisfied: requests>=1.1 in /Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages (from requests_unixsocket) (2.31.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages (from requests>=1.1->requests_unixsocket) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in /Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages (from requests>=1.1->requests_unixsocket) (3.6)
Requirement already satisfied: urllib3<3,>=1.21.1 in /Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages (from requests>=1.1->requests_unixsocket) (1.26.18)
Requirement already satisfied: certifi>=2017.4.17 in /Users/tester/miniconda3/envs/skyflow-slurm/lib/python3.9/site-packages (from requests>=1.1->requests_unixsocket) (2024.2.2)
Downloading requests_unixsocket-0.3.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: requests_unixsocket
Successfully installed requests_unixsocket-0.3.0
$ python api_server/launch_server.py --workers=1
[Installer] ETCD is running.
API server config already exists. Skipping generation.
INFO:     Started server process [96288]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:50051 (Press CTRL+C to quit)
```