### PR TITLE
Fix Pydantic Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     extras_require={
         "server": [
-            "etcd3", "fastapi", "uvicorn[standard]", "pydantic>=2.5.0",
+            "etcd3", "fastapi", "uvicorn[standard]", "pydantic[email]>=2.5.0",
             'jsonpatch', "pyjwt",
         ],
         "dev": [


### PR DESCRIPTION
The API server requires the optional email validation which was missing before.

```
vscode ➜ /workspaces/skyflow (main) $ python api_server/launch_server.py 
Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/networks.py", line 381, in import_email_validator
    import email_validator
ModuleNotFoundError: No module named 'email_validator'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/workspaces/skyflow/api_server/launch_server.py", line 12, in <module>
    from skyflow.utils.utils import generate_manager_config
  File "/workspaces/skyflow/skyflow/__init__.py", line 4, in <module>
    from skyflow.etcd_client.etcd_client import ETCD_PORT, ETCDClient
  File "/workspaces/skyflow/skyflow/etcd_client/__init__.py", line 4, in <module>
    from skyflow.etcd_client.etcd_client import ETCD_PORT, ETCDClient
  File "/workspaces/skyflow/skyflow/etcd_client/etcd_client.py", line 26, in <module>
    from skyflow.templates.event_template import WatchEventEnum
  File "/workspaces/skyflow/skyflow/templates/__init__.py", line 31, in <module>
    from skyflow.templates.user_template import User
  File "/workspaces/skyflow/skyflow/templates/user_template.py", line 7, in <module>
    class User(BaseModel):
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_model_construction.py", line 202, in __new__
    complete_model_class(
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_model_construction.py", line 539, in complete_model_class
    schema = cls.__get_pydantic_core_schema__(cls, handler)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/main.py", line 607, in __get_pydantic_core_schema__
    return handler(source)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_schema_generation_shared.py", line 82, in __call__
    schema = self._handler(source_type)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 499, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 750, in _generate_schema_inner
    return self._model_schema(obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 577, in _model_schema
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 577, in <dictcomp>
    {k: self._generate_md_field_schema(k, v, decorators) for k, v in fields.items()},
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 913, in _generate_md_field_schema
    common_field = self._common_field_schema(name, field_info, decorators)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1078, in _common_field_schema
    schema = self._apply_annotations(
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1817, in _apply_annotations
    schema = get_inner_schema(source_type)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_schema_generation_shared.py", line 82, in __call__
    schema = self._handler(source_type)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1798, in inner_handler
    schema = self._generate_schema_inner(obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 755, in _generate_schema_inner
    return self.match_type(obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 837, in match_type
    return self._match_generic_type(obj, origin)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 861, in _match_generic_type
    return self._union_schema(obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1149, in _union_schema
    choices.append(self.generate_schema(arg))
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 494, in generate_schema
    from_property = self._generate_schema_from_property(obj, obj)
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 645, in _generate_schema_from_property
    schema = get_schema(
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/networks.py", line 421, in __get_pydantic_core_schema__
    import_email_validator()
  File "/home/vscode/.local/lib/python3.9/site-packages/pydantic/networks.py", line 383, in import_email_validator
    raise ImportError('email-validator is not installed, run `pip install pydantic[email]`') from e
ImportError: email-validator is not installed, run `pip install pydantic[email]`
```