### PR TITLE
Fix SkyShift/SkyFlow Launch script

### DIFF
--- a/launch_skyflow.sh
+++ b/launch_skyflow.sh
@@ -96,9 +96,9 @@ terminate_skyflow() {
 
   # While these processes exist, kill them.
   while pgrep -f launch_server.py || pgrep -f launch_sky_manager.py; do
-    pkill -f launch_server.py
+    pkill -9 -f launch_server.py
     pkill -9 -f "multiprocessing.spawn"
-    pkill -f launch_sky_manager.py
+    pkill -9 -f launch_sky_manager.py
     sleep 1
   done
 


### PR DESCRIPTION
This PR sends both SIGINT and SIGKILL to the API server and Sky Manager processes once `./launch_skyflow.sh --kill` is executed.