### PR TITLE
Ensure Skylet is Alive when Cluster is in`ERROR` state

### DIFF
--- a/skyflow/controllers/skylet_controller.py
+++ b/skyflow/controllers/skylet_controller.py
@@ -70,7 +70,6 @@ class SkyletController(Controller):
         self.cluster_informer.start()
 
     def run(self):
-        # Establish a watch over added clusters.
         self.logger.info(
             "Executing Skylet controller - Manages launching and terminating Skylets for clusters."
         )
@@ -94,7 +93,7 @@ class SkyletController(Controller):
                 self._launch_skylet(cluster_obj)
                 self.logger.info('Launched Skylet for cluster: %s.',
                                  cluster_name)
-        else:
+        elif event_type == WatchEventEnum.DELETE:
             # Terminate Skylet controllers if the cluster is deleted.
             self._terminate_skylet(cluster_obj)
             self.logger.info("Terminated Skylet for cluster: %s.",

--- a/skyflow/skylet/cluster_controller.py
+++ b/skyflow/skylet/cluster_controller.py
@@ -19,7 +19,7 @@ from skyflow.controllers.controller_utils import create_controller_logger
 from skyflow.globals import cluster_dir
 from skyflow.templates.cluster_template import ClusterStatus, ClusterStatusEnum
 
-DEFAULT_HEARTBEAT_TIME = 3  # seconds
+DEFAULT_HEARTBEAT_TIME = 5  # seconds
 DEFAULT_RETRY_LIMIT = 5  # attempts
 
 


### PR DESCRIPTION
Solves #25. Very simple PR... 

However, the user will still have to manually delete and add the cluster back if the credentials change. This mimics the case where admins have to manually remove and add nodes in the K8 cluster if any node dies.

This code will still work if the underlying cluster was not working but is working again without credential changes. On my end, it was able to quickly resume clusters, jobs, and service states.
