### PR TITLE
feat: add GCP dependencies to skypilot installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "pyyaml",
         "requests>=2.31.0",
         "rich",
-        "skypilot==0.5.0",
+        "skypilot[gcp]==0.5.0",
         "paramiko",
         "scp",
         "tabulate",


### PR DESCRIPTION
This PR adds GCP dependencies to the default skypilot installation in skyshift.

### Problem
Users were encountering errors when trying to use GCP features because the required dependencies were not installed by default:
```
Failed to import dependencies for GCP. Try: pip install "skypilot[gcp]"
```

### Solution
Modified `setup.py` to include GCP dependencies by default by changing the skypilot requirement from `skypilot==0.5.0` to `skypilot[gcp]==0.5.0`. This ensures that when users install skyshift, they automatically get the GCP dependencies for skypilot.

### Testing
- [ ] Install skyshift in a fresh environment
- [ ] Verify that GCP features work without additional dependency installation